### PR TITLE
Add custom range to flirt

### DIFF
--- a/flirt/hrv/feature_calculation.py
+++ b/flirt/hrv/feature_calculation.py
@@ -39,7 +39,7 @@ FEATURE_FUNCTIONS = {
 }
 
 
-def get_hrv_features(data: pd.Series, window_length: int = 180, window_step_size: int = 1,
+def get_hrv_features(data: pd.Series, window_length: int = 180, window_step_size: int = 1, custom_range = None,
                      domains: List[str] = ['td', 'fd', 'stat'], threshold: float = 0.2,
                      clean_data: bool = True, num_cores: int = 0):
     """
@@ -118,9 +118,13 @@ def get_hrv_features(data: pd.Series, window_length: int = 180, window_step_size
 
     first_index = clean_data.index[0].floor('s')
     last_index = clean_data.index[-1].ceil('s')
-    target_index = pd.date_range(start=first_index,
-                                 end=max(first_index, last_index - window_length_timedelta),
-                                 freq=window_step_size_timedelta)
+    
+    if custom_range is None:
+        target_index = pd.date_range(start=first_index,
+                                     end=max(first_index, last_index - window_length_timedelta),
+                                     freq=window_step_size_timedelta)
+    else:
+        target_index = first_index + pd.to_timedelta(custom_range, unit='s')
 
     def process(memmap_data) -> pd.DataFrame:
         with Parallel(n_jobs=num_cores, max_nbytes=None) as parallel:

--- a/flirt/stats/feature_calculation.py
+++ b/flirt/stats/feature_calculation.py
@@ -3,14 +3,14 @@ from datetime import timedelta
 
 import pandas as pd
 from joblib import Parallel, delayed
-from tqdm.autonotebook import trange
+from tqdm.autonotebook import trange, tqdm
 from ..util import processing
 
 from .common import get_stats
 
 
 def get_stat_features(data: pd.DataFrame, window_length: int = 60, window_step_size: int = 1, data_frequency: int = 32,
-                      entropies: bool = True, num_cores: int = 0):
+                      custom_range = None, entropies: bool = True, num_cores: int = 0):
     """
     Computes several statistical and entropy-based time series features for each column in the provided DataFrame.
 
@@ -49,8 +49,12 @@ def get_stat_features(data: pd.DataFrame, window_length: int = 60, window_step_s
         num_cores = multiprocessing.cpu_count()
 
     input_data = data.copy()
-    # advance by window_step_size * data_frequency
-    inputs = trange(0, len(input_data) - 1, window_step_size * data_frequency, desc="Stat features")
+    
+    if custom_range is None:
+        # advance by window_step_size * data_frequency
+        inputs = trange(0, len(input_data) - 1, window_step_size * data_frequency, desc="Stat features")
+    else:
+        inputs = tqdm(custom_range, desc="Stat features")
 
     def process(memmap_data):
         with Parallel(n_jobs=num_cores, max_nbytes=None) as parallel:


### PR DESCRIPTION
Add "custom_range" parameter to stats and hrv feature functions which allows user to specify a custom time range. This is useful if only certain sections of the time series are of interest.