### PR TITLE
fixed EDA feature cvx matrix creation

### DIFF
--- a/flirt/eda/feature_calculation.py
+++ b/flirt/eda/feature_calculation.py
@@ -136,6 +136,7 @@ def __cvx_eda(y, delta, tau0=2., tau1=0.7, delta_knot=10., alpha=8e-4, gamma=1e-
     """
 
     n = len(y)
+    y = y.astype(np.double)
     y = cvx.matrix(y)
 
     # bateman ARMA model
@@ -176,7 +177,7 @@ def __cvx_eda(y, delta, tau0=2., tau1=0.7, delta_knot=10., alpha=8e-4, gamma=1e-
     cvx.solvers.options.update(options)
     if solver == 'conelp':
         # Use conelp
-        z = lambda m, n: cvx.spmatrix([], [], [], (m, n))
+        def z(m, n): return cvx.spmatrix([], [], [], (m, n))
         G = cvx.sparse([[-A, z(2, n), M, z(nB + 2, n)], [z(n + 2, nC), C, z(nB + 2, nC)],
                         [z(n, 1), -1, 1, z(n + nB + 2, 1)], [z(2 * n + 2, 1), -1, 1, z(nB, 1)],
                         [z(n + 2, nB), B, z(2, nB), cvx.spmatrix(1.0, range(nB), range(nB))]])

--- a/flirt/eda/feature_calculation.py
+++ b/flirt/eda/feature_calculation.py
@@ -136,7 +136,6 @@ def __cvx_eda(y, delta, tau0=2., tau1=0.7, delta_knot=10., alpha=8e-4, gamma=1e-
     """
 
     n = len(y)
-    y = y.astype(np.double)
     y = cvx.matrix(y)
 
     # bateman ARMA model

--- a/flirt/eda/feature_calculation.py
+++ b/flirt/eda/feature_calculation.py
@@ -136,6 +136,7 @@ def __cvx_eda(y, delta, tau0=2., tau1=0.7, delta_knot=10., alpha=8e-4, gamma=1e-
     """
 
     n = len(y)
+    y = y.astype(np.double)
     y = cvx.matrix(y)
 
     # bateman ARMA model


### PR DESCRIPTION
# Fixing EDA CVX matrix creation

Related to issue #6 

The `cvx.matrix` call can raise a `buffer format not supported` exception resulting in an empty end DataFrame from feature extraction.

This is due to the `y` input format being in `float32` instead of `float64`

https://stackoverflow.com/questions/33423081/converting-numpy-vector-to-cvxopt#answers
https://github.com/cvxopt/cvxopt/blob/3b718ee560b3b97d6255c55f0ed7f64cb4b72082/src/C/dense.c#L231

### Past code
``` Python
...
n = len(y)
y = cvx.matrix(y)
...
```

### Modifyed code
``` Python
...
n = len(y)
y = y.astype(np.double)
y = cvx.matrix(y)
...
```